### PR TITLE
NEW dump function and datetime_field on constructor

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-mamba
+mamba<0.11.0
 pandas==0.23.4
 pytz
 expects


### PR DESCRIPTION
* The `datetime_field` my be set on costructor:

```python
powpro = PowerProfile(datetime_field='utc_datetime')
powpro.load(curve)
```
is identical to:

```python
powpro = PowerProfile()
powpro.load(curve, datetime_field='utc_datetime')
```

* Adds a `dump` function that returns de curve as a dict list. You may perform a complet `load -> dump` and obtain the same original curve:

```python
original_curve = [
    {'timestamp': TIMEZONE.localize(datetime.datetime(2020,1,1,0)), 'value': 100}, 
    {'timestamp': TIMEZONE.localize(datetime.datetime(2020,1,1,1)), 'value': 200},
    {'timestamp': TIMEZONE.localize(datetime.datetime(2020,1,1,2)), 'value': 200},
]
powpro = PowerProfile()
powpro.load(original_curve)
new_curve = powpro.dump()
# new_curve == original_curve
```

