### PR TITLE
New arithmetic operators

### DIFF
--- a/powerprofile/exceptions.py
+++ b/powerprofile/exceptions.py
@@ -7,3 +7,11 @@ class PowerProfileIncompleteCurve(ValueError):
 
 class PowerProfileDuplicatedTimes(ValueError):
     pass
+
+
+class PowerProfileNotImplemented(NotImplementedError):
+    pass
+
+
+class PowerProfileIncompatible(ValueError):
+    pass


### PR DESCRIPTION
# Add arithmetic operators `+` `-` and `*` 
* PowerProfile and scalar (float or integer)
* PowerProfile and PowerProfile

## Other functionalities:

 * Validates Compatibility between PowerProfile's (`PowerProfileIncompatible` Exception)
 * Allows column selection

## Example:

```
a = PowerProfile(data_fields=['value'])
a.load(data1)

b = PowerProfile(data_fields=['value'])
b.load(data2)

c = a + b
d = a * 2
```