### PR TITLE
ADD _fix fields to data_fields

### DIFF
--- a/powerprofile/powerprofile.py
+++ b/powerprofile/powerprofile.py
@@ -18,7 +18,7 @@ UTC_TIMEZONE = timezone('UTC')
 
 
 DEFAULT_DATA_FIELDS_NO_FACT = ['ae', 'ai', 'r1', 'r2', 'r3', 'r4']
-DEFAULT_DATA_FIELDS = DEFAULT_DATA_FIELDS_NO_FACT + [f + '_fact' for f in DEFAULT_DATA_FIELDS_NO_FACT] + ['value']
+DEFAULT_DATA_FIELDS = DEFAULT_DATA_FIELDS_NO_FACT + [f + '_fact' for f in DEFAULT_DATA_FIELDS_NO_FACT] + [f + '_fix' for f in DEFAULT_DATA_FIELDS_NO_FACT] + ['value']
 
 
 class PowerProfile():


### PR DESCRIPTION
Powerprofiles now usualy have the `_fix` fields in addition to the `_fact` fields. They should be considered as default data fields in order to make operations easyer as it have been done with `_fact` fields.