### PR TITLE
New is fixed

### DIFF
--- a/powerprofile/exceptions.py
+++ b/powerprofile/exceptions.py
@@ -32,3 +32,12 @@ class PowerProfileNotImplemented(NotImplementedError):
 
     def __str__(self):
         return 'Operation not implemented: ' + self.message
+
+
+class PowerProfileMissingField(PowerProfileExceptionBaseClass):
+
+    def __init__(self, field=''):
+        self.field = field
+
+    def __str__(self):
+        return "Field does not exist in profile: {}" + self.field

--- a/powerprofile/powerprofile.py
+++ b/powerprofile/powerprofile.py
@@ -93,6 +93,23 @@ class PowerProfile():
             return False
         return True
 
+    def is_fixed(self, fields=['cch_fact', 'valid']):
+        """
+        Given a list of fields, check all values are True in every register
+        :param fields []:
+        :return: list
+        """
+        for field in fields:
+            try:
+                data = self.curve.loc[self.curve[field] == False]
+            except KeyError as e:
+                raise PowerProfileMissingField(field)
+
+            if len(data) > 0:
+                return False
+            else:
+                return True
+
     def has_duplicates(self):
         ''' Checks for duplicated hours'''
         uniques = len(self.curve[self.datetime_field].unique())

--- a/spec/exceptions_spec.py
+++ b/spec/exceptions_spec.py
@@ -8,6 +8,7 @@ except_data = [
     (PowerProfileIncompatible, "PowerProfile Incompatible"),
     (PowerProfileIncompleteCurve, "PowerProfile Incomplete Curve"),
     (PowerProfileNotImplemented, "Operation not implemented"),
+    (PowerProfileMissingField, "Field does not exist in profile: "),
 ]
 
 


### PR DESCRIPTION
Adds new function to test the curve is fixed, usually cch_facy field and valid field. 

`is_fixed`: gets a list of fields that has to be True as a parameter

If the field is not in the curve, it trows a `PowerProfileMissingField` exception

```python
powerprofile = PowerProfile()
powerprofile.load(curve)
res = powerprofile.check(['valid', 'cch_fact'])
print('Result: {}'.format(res and 'True' or 'False'))
```