### PR TITLE
Nueva función para elevar a pérdidas las curvas leídas en baja tensión

### DIFF
--- a/powerprofile/powerprofile.py
+++ b/powerprofile/powerprofile.py
@@ -180,6 +180,23 @@ class PowerProfile():
         self.curve[magn1 + sufix] = self.curve.apply(lambda row: balance(row[magn1], row[magn2]), axis=1)
         self.curve[magn2 + sufix] = self.curve.apply(lambda row: balance(row[magn2], row[magn1]), axis=1)
 
+    def ApplyLbtLosses(self, trafo, losses, sufix='_fix'):
+        """
+        Adds losses and trafo charge to consumption. Subs losses to generation.
+        :param trafo: float (expressed in kVA)
+        :param losses: float (usually, 0.04)
+        :param sufix: str (magn where to apply losses, usually '_fix')
+        :return:
+        """
+        def elevate(kva, losses, value):
+            return round(value * (1 + losses), 2) + round(0.01 * kva, 2)
+
+        def descend(losses, value):
+            return round(value * (1 - losses), 2)
+
+        self.curve['ai' + sufix] = self.curve.apply(lambda row: elevate(trafo, losses, row['ai']), axis=1)
+        self.curve['ae' + sufix] = self.curve.apply(lambda row: descend(losses, row['ae']), axis=1)
+
     def Min(self, magn1='ae', magn2='ai', sufix='ac'):
         """
         Allows easy AUTOCONSUMED curve from a curve with both exported and imported energy

--- a/powerprofile/powerprofile.py
+++ b/powerprofile/powerprofile.py
@@ -194,8 +194,8 @@ class PowerProfile():
         def descend(losses, value):
             return round(value * (1 - losses), 2)
 
-        self.curve['ai' + sufix] = self.curve.apply(lambda row: elevate(trafo, losses, row['ai']), axis=1)
-        self.curve['ae' + sufix] = self.curve.apply(lambda row: descend(losses, row['ae']), axis=1)
+        self.curve['ai' + sufix] = self.curve.apply(lambda row: elevate(trafo, losses, row['ai' + sufix]), axis=1)
+        self.curve['ae' + sufix] = self.curve.apply(lambda row: descend(losses, row['ae' + sufix]), axis=1)
 
     def Min(self, magn1='ae', magn2='ai', sufix='ac'):
         """

--- a/powerprofile/powerprofile.py
+++ b/powerprofile/powerprofile.py
@@ -182,14 +182,14 @@ class PowerProfile():
 
     def ApplyLbtLosses(self, trafo, losses, sufix='_fix'):
         """
-        Adds losses and trafo charge to consumption. Subs losses to generation.
+        Adds losses and trafo charge to consumption. Subs losses to generation. Curve is expressed in Wh.
         :param trafo: float (expressed in kVA)
         :param losses: float (usually, 0.04)
         :param sufix: str (magn where to apply losses, usually '_fix')
         :return:
         """
         def elevate(kva, losses, value):
-            return round(value * (1 + losses), 2) + round(0.01 * kva, 2)
+            return round(value * (1 + losses), 2) + round(10 * kva, 2)
 
         def descend(losses, value):
             return round(value * (1 - losses), 2)

--- a/spec/powerprofile_spec.py
+++ b/spec/powerprofile_spec.py
@@ -439,6 +439,26 @@ with description('PowerProfile Manipulation'):
                     row = powpro[i]
                     expect(row['aeac']).to(equal(min(row['ae'], row['ai'])))
 
+        with context('ApplyLbtLosses'):
+            with it('Performs an application of LBT losses and store it in sufix columns'):
+                powpro = PowerProfile()
+                powpro.load(self.erp_curve['curve'], datetime_field='utc_datetime')
+
+                # Prepare _fix columns
+                powpro.curve['ai_fix'] = powpro.curve['ai']
+                powpro.curve['ae_fix'] = powpro.curve['ae']
+
+                trafo = 50  # kVA
+                losses = 0.04  # %
+                sufix = '_fix'  # 'ae_fix' and 'ai_fix'
+                powpro.ApplyLbtLosses(trafo, losses, sufix)
+
+                expect(powpro.check()).to(be_true)
+                for i in range(powpro.hours):
+                    row = powpro[i]
+                    expect(round(row['ai_fix'], 1)).to(equal(round((row['ai'] * (1 + losses) + (10 * trafo)), 1)))
+                    expect(round(row['ae_fix'], 1)).to(equal(round((row['ae'] * (1 - losses)), 1)))
+
 with description('PowerProfile Operators'):
     with before.all:
         self.data_path = './spec/data/'


### PR DESCRIPTION
## Objetivo

- Si el contrato tiene lectura en baja tensión, se deben aplicar las siguientes correcciones en la curva:
  - Magnitud `ai`: Se deben sumar las pérdidas (habitualmente aplicando un 4%) y el recargo del transformador (0,01 kWh por el valor de la potencia aparente expresada en kVA).
  - Magnitud `ae`: Se deben restar las pérdidas (habitualmente sustrayendo un 4%).

## Relacionado

- Closes https://github.com/gisce/erp/issues/14034
