### PR TITLE
Correcciones en el arrastre de decimales en las curvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 # powerprofile
+
+.. image:: https://github.com/gisce/powerprofile/actions/workflows/python2-app.yml/badge.svg
+    :target: https://github.com/gisce/powerprofile/actions/workflows/python2-app.yml
+
+.. image:: https://github.com/gisce/powerprofile/actions/workflows/python3-app.yml/badge.svg
+    :target: https://github.com/gisce/powerprofile/actions/workflows/python3-app.yml
+
 Electric Power Curve and Profiles library
 
 Libray to manipulate easily profiles and operate with and between them

--- a/powerprofile/powerprofile.py
+++ b/powerprofile/powerprofile.py
@@ -238,7 +238,7 @@ class PowerProfile():
         """
         for magn in magns:
             draggers = Dragger()
-            self.curve[magn] = self.curve.apply(lambda row: draggers.drag(round(row[magn] / 1000, 2)), axis=1)
+            self.curve[magn] = self.curve.apply(lambda row: draggers.drag(round(row[magn] / 1000, 6)), axis=1)
             self.curve[magn] = self.curve.apply(lambda row: row[magn] * 1000, axis=1)
 
     def Min(self, magn1='ae', magn2='ai', sufix='ac'):

--- a/powerprofile/powerprofile.py
+++ b/powerprofile/powerprofile.py
@@ -208,13 +208,12 @@ class PowerProfile():
         self.curve[magn1 + sufix] = self.curve.apply(lambda row: balance(row[magn1], row[magn2]), axis=1)
         self.curve[magn2 + sufix] = self.curve.apply(lambda row: balance(row[magn2], row[magn1]), axis=1)
 
-    def ApplyLbtLosses(self, trafo, losses, sufix='_fix', dragging=True):
+    def ApplyLbtLosses(self, trafo, losses, sufix='_fix'):
         """
         Adds losses and trafo charge to consumption. Subs losses to generation. Curve is expressed in Wh.
         :param trafo: float (expressed in kVA)
         :param losses: float (usually, 0.04)
         :param sufix: str (magn where to apply losses, usually '_fix')
-        :param dragging: bool (if True, magns are dragged after apply LBT losses)
         :return:
         """
         def elevate(kva, losses, value):
@@ -225,10 +224,6 @@ class PowerProfile():
 
         self.curve['ai' + sufix] = self.curve.apply(lambda row: elevate(trafo, losses, row['ai' + sufix]), axis=1)
         self.curve['ae' + sufix] = self.curve.apply(lambda row: descend(losses, row['ae' + sufix]), axis=1)
-
-        # Avoid decimal values on measures files, dragging them before balance
-        if dragging:
-            self.drag(['ai' + sufix, 'ae' + sufix])
 
     def drag(self, magns):
         """

--- a/powerprofile/powerprofile.py
+++ b/powerprofile/powerprofile.py
@@ -238,7 +238,8 @@ class PowerProfile():
         """
         for magn in magns:
             draggers = Dragger()
-            self.curve[magn] = self.curve.apply(lambda row: draggers.drag(round(row[magn], 2)), axis=1)
+            self.curve[magn] = self.curve.apply(lambda row: draggers.drag(round(row[magn] / 1000, 2)), axis=1)
+            self.curve[magn] = self.curve.apply(lambda row: row[magn] * 1000, axis=1)
 
     def Min(self, magn1='ae', magn2='ai', sufix='ac'):
         """

--- a/spec/powerprofile_spec.py
+++ b/spec/powerprofile_spec.py
@@ -488,8 +488,9 @@ with description('PowerProfile Manipulation'):
                 expect(powpro.check()).to(be_true)
                 for i in range(powpro.hours):
                     row = powpro[i]
-                    assert abs(round(row['ai_fix'], 1) - round((row['ai'] * (1 + losses) + (10 * trafo)), 1)) <= 1.0
-                    assert abs(round(row['ae_fix'], 1) - round((row['ae'] * (1 - losses)), 1)) <= 1.0
+                    # Max error allower is 1000 Wh (1 kWh)
+                    assert abs(round(row['ai_fix'], 1) - round((row['ai'] * (1 + losses) + (10 * trafo)), 1)) <= 1000.0
+                    assert abs(round(row['ae_fix'], 1) - round((row['ae'] * (1 - losses)), 1)) <= 1000.0
 
         with context('Dragg'):
             with it('Performs a dragging operation through float values of specified magnitudes on curve'):
@@ -506,8 +507,9 @@ with description('PowerProfile Manipulation'):
                 dragged_ai_sum = powpro.curve['ai'].sum()
                 dragged_ae_sum = powpro.curve['ae'].sum()
 
-                assert abs(real_ai_sum - dragged_ai_sum) <= 1.0
-                assert abs(real_ae_sum - dragged_ae_sum) <= 1.0
+                # Max error allower is 1000 Wh (1 kWh)
+                assert abs(real_ai_sum - dragged_ai_sum) <= 1000.0
+                assert abs(real_ae_sum - dragged_ae_sum) <= 1000.0
 
 with description('PowerProfile Operators'):
     with before.all:


### PR DESCRIPTION
## Objetivo

- Corregir el `dragger`, ya que la curva se expresa siempre en `Wh`.
- La función se dejará en la librería, pero se elimina su uso en la elevación a pérdidas de los suministros con lectura en baja para que se encargue de ello el facturador y no esta librería.

## Relacionado

- Fixes https://github.com/gisce/powerprofile/pull/18
