### PR TITLE
Ensure always working with localized datetimes

### DIFF
--- a/powerprofile/powerprofile.py
+++ b/powerprofile/powerprofile.py
@@ -51,6 +51,8 @@ class PowerProfile():
         self.curve = pd.DataFrame(data)
         self.curve.sort_values(by=self.datetime_field, inplace=True)
         self.curve.reset_index(inplace=True, drop=True)
+        # Ensure timestamp field is localized
+        self.curve[self.datetime_field] = self.curve.apply(lambda row: self.ensure_localized_dt(row), axis=1)
 
         if start:
             self.start = start
@@ -71,6 +73,13 @@ class PowerProfile():
                 if field in loaded_data_fields and field in self.data_fields:
                     auto_data_fields.append(field)
             self.data_fields = auto_data_fields
+
+    def ensure_localized_dt(self, row):
+        dt = row[self.datetime_field]
+        if dt.tzinfo is None:
+            return TIMEZONE.localize(dt)
+        else:
+            return dt
 
     def dump(self):
 

--- a/spec/powerprofile_spec.py
+++ b/spec/powerprofile_spec.py
@@ -160,6 +160,19 @@ with description('PowerProfile class'):
                 expect(lambda: powpro.load(curve_name, data_fields=['value'])).to_not(raise_error(TypeError))
                 expect(powpro[0]).to(have_key('value'))
 
+        with context('with unlocalized datetimes'):
+            with before.all:
+                self.curve = []
+                self.start = datetime(2022, 8, 1, 1, 0, 0)
+                self.end = datetime(2022, 9, 1, 0, 0, 0)
+                for hours in range(0, 24):
+                    self.curve.append({'timestamp': self.start + timedelta(hours=hours), 'value': 100 + hours})
+            with it('should localize datetimes on load'):
+                powerprofile = PowerProfile()
+                powerprofile.load(self.curve)
+                for idx, hour in powerprofile.curve.iterrows():
+                    assert hour[powerprofile.datetime_field].tzinfo is not None
+
     with context('dump function'):
         with before.all:
             self.curve = []


### PR DESCRIPTION
- `load` function must localize datetimes if there is no timezone specified on importing curve.