### PR TITLE
Mejoras en la función que valida la completitud de una curva

### DIFF
--- a/powerprofile/powerprofile.py
+++ b/powerprofile/powerprofile.py
@@ -106,7 +106,10 @@ class PowerProfile():
             dt = start
             df_hours = set([TIMEZONE.normalize(dt + timedelta(hours=x)) for x in range(0, int(hours))])
             not_found = sorted(list(df_hours - ids))
-            first_not_found = not_found[0]
+            if len(not_found):
+                first_not_found = not_found[0]
+            else:
+                first_not_found = dt
             return False, first_not_found
         return True, None
 

--- a/spec/powerprofile_spec.py
+++ b/spec/powerprofile_spec.py
@@ -263,6 +263,15 @@ with description('PowerProfile class'):
                 expect(self.powpro.is_complete()[0]).to(be_false)
                 expect(lambda: self.powpro.check()).to(raise_error(PowerProfileIncompleteCurve))
 
+            with it('returns false when complete but duplicated hours'):
+                curve = copy(self.curve)
+                curve.append(curve[-1])
+                self.powpro.load(curve, self.start, self.end)
+
+                expect(self.powpro.is_complete()[0]).to(be_false)
+                expect(self.powpro.is_complete()[1]).to(equal(curve[0]['timestamp']))
+                expect(lambda: self.powpro.check()).to(raise_error(PowerProfileDuplicatedTimes))
+
         with context('duplicated hours'):
 
             with it('returns true when not duplicates'):


### PR DESCRIPTION
## Objetivo

- El caso de tener una curva con todas las horas de un periodo pero con duplicidades, no debe hacer fallar la función `is_complete`.
