### PR TITLE
Correcciones en la función "copy"

### DIFF
--- a/powerprofile/powerprofile.py
+++ b/powerprofile/powerprofile.py
@@ -380,6 +380,7 @@ class PowerProfile():
         new.start = self.start
         new.end = self.end
         new.curve = copy.copy(self.curve)
+        new.data_fields = copy.copy(self.data_fields)
 
         return new
 


### PR DESCRIPTION
## Objetivos

- La función `copy` que crea una réplica del objeto "powerprofile" original, debe heredar del original el listado de campos de información (`data_fields`).
