### PR TITLE
New max/min timestamp

### DIFF
--- a/powerprofile/powerprofile.py
+++ b/powerprofile/powerprofile.py
@@ -254,23 +254,35 @@ class PowerProfile():
             res[magn] = totals[magn]
         return res
 
-    def max(self, magn):
+    def max(self, magn, ret='value'):
         """
         Returns max value of given magnitude of the curve
         :param magn: magnitude value
+        :param ret: value or timestamp of maximum
         :return: max magnitude value
         """
         if self._check_magn_is_valid(magn):
-            return self.curve[magn].max()
+            if ret == 'value':
+                return self.curve[magn].max()
+            elif ret == 'timestamp':
+                idx_max = self.curve[magn].idxmax()
+                return self[idx_max][self.datetime_field]
 
-    def min(self, magn):
+    def min(self, magn, ret='value'):
         """
         Returns min value of given magnitude of the curve
         :param magn: magnitude value
+        :param ret: value or timestamp of minimum
         :return: min magnitude value
         """
         if self._check_magn_is_valid(magn):
-            return self.curve[magn].min()
+            if ret == 'value':
+                return self.curve[magn].min()
+            elif ret == 'timestamp':
+                idx_min = self.curve[magn].idxmin()
+                return self[idx_min][self.datetime_field]
+
+            return False
 
     def avg(self, magn):
         """

--- a/spec/powerprofile_spec.py
+++ b/spec/powerprofile_spec.py
@@ -680,14 +680,21 @@ with description('PowerProfile Manipulation'):
                 powpro.load(curve_all['curve'], datetime_field='timestamp')
 
                 min_ai = powpro.min('ai')
+                min_ai_timestamp = powpro.min('ai', 'timestamp')
                 min_ae = powpro.min('ae')
+                min_ae_timestamp = powpro.min('ae', 'timestamp')
 
-                json_min_ai = min(curve_all['curve'], key=lambda x:x['ai'])
+                json_min_ai = min(curve_all['curve'], key=lambda x: x['ai'])
                 json_min_ae = min(curve_all['curve'], key=lambda x: x['ae'])
 
                 expect(min_ai).to(equal(json_min_ai['ai']))
+                expect(min_ai_timestamp).to(
+                    equal(LOCAL_TZ.localize(datetime(2022, 2, 1, 11)))
+                )
                 expect(min_ae).to(equal(json_min_ae['ae']))
-
+                expect(min_ae_timestamp).to(
+                    equal(LOCAL_TZ.localize(datetime(2022, 2, 1, 1)))
+                )
             with it('returns error if magn is invalid'):
                 data_path = './spec/data/'
                 with open(data_path + 'demo_ac_curve.json') as fp:
@@ -710,13 +717,22 @@ with description('PowerProfile Manipulation'):
                 powpro.load(curve_all['curve'], datetime_field='timestamp')
 
                 max_ai = powpro.max('ai')
+                max_ai_timestamp = powpro.max('ai', 'timestamp')
                 max_ae = powpro.max('ae')
+                max_ae_timestamp = powpro.max('ae', 'timestamp')
+
 
                 json_max_ai = max(curve_all['curve'], key=lambda x: x['ai'])
                 json_max_ae = max(curve_all['curve'], key=lambda x: x['ae'])
 
                 expect(max_ai).to(equal(json_max_ai['ai']))
+                expect(max_ai_timestamp).to(
+                    equal(LOCAL_TZ.localize(datetime(2022, 2, 12, 23)))
+                )
                 expect(max_ae).to(equal(json_max_ae['ae']))
+                expect(max_ae_timestamp).to(
+                    equal(LOCAL_TZ.localize(datetime(2022, 2, 22, 14)))
+                )
 
             with it('returns error if magn is invalid'):
                 data_path = './spec/data/'


### PR DESCRIPTION
## Objetivos

- Nueva funcionalidad para saber la hora del máximo y del mínimo de una curva. Se modifican las funciones `max` y `min` añadiendo un parámetro nuevo `ret` con 2 posibles valores:
-  'value': máximo o mínimo
- 'timestamp': hora del máximo o mínim

```
pp = PowerProfile()
pp.load(curve_data)
# valor máximo de la curva
value = pp.max()
# hora del máximo de la curva
timestamp = pp.max(ret = 'timestamp')
```
## Checklist

- [x] Test code
