### PR TITLE
Añadir filtro para validar que una magnitud no sea mayor de 0

### DIFF
--- a/powerprofile/powerprofile.py
+++ b/powerprofile/powerprofile.py
@@ -284,6 +284,17 @@ class PowerProfile():
 
             return False
 
+    def min_not_0(self, magn, magn_not_0, ret='value'):
+        curva_not_0 = self.curve[(self.curve[magn_not_0] == 0) & (self.curve[magn] > 0)]
+        if self._check_magn_is_valid(magn):
+            if ret == 'value':
+                return curva_not_0[magn].min()
+            elif ret == 'timestamp':
+                idx_min = curva_not_0[magn].idxmin()
+                return self[idx_min][self.datetime_field]
+
+            return False
+        
     def avg(self, magn):
         """
         Returns avg value of given magnitude of the curve


### PR DESCRIPTION
## Objetivos

- Crear nueva funcionalidad, para validar que dada una magnitud esta sea solo aplique sobre estas que su valor sea 0
    - Filtramos la curve para que solo tenga en cuenta valores de 0 sobre la magnitud `magn_0 dada
    - Le pasamos por parámetro que queremos que devuelva, la magnitud sobre la que trabajar y la magnitud sobre la que filtrara la `curve` con valores unicos de 0

## Relacionado

* Requires https://github.com/gisce/erp/pull/19546
