### PR TITLE
FIX comprobar magnitudes de la curva

### DIFF
--- a/powerprofile/powerprofile.py
+++ b/powerprofile/powerprofile.py
@@ -683,7 +683,7 @@ class PowerProfile():
         :param magn: Magnitude
         :return: bool
         """
-        if magn in DEFAULT_DATA_FIELDS_NO_FACT:
+        if magn in self.data_fields:
             return True
         raise ValueError("ERROR: [magn] is not a valid parameter, given magn: {}".format(magn))
 


### PR DESCRIPTION
## Objetivos

- Aceptar magnitudes de la curva a la hora de comprar si la magnitud es correcta a funciones `min`, `max`, `avg` i `std`.

## Comportamiento antiguo

- Solo se comprobaban magnitudes dentro de las `DEFAULT`.

## Comportamiento nuevo

- Se comprueban todas las magnitudes de la curva.
