### PR TITLE
FIX fill_gaps, se añade soporte para llenar más campos de fecha

### DIFF
--- a/powerprofile/powerprofile.py
+++ b/powerprofile/powerprofile.py
@@ -730,8 +730,8 @@ class PowerProfile():
                 self.curve[column] = self.curve[self.datetime_field].dt.tz_convert(tz_info)
 
         self.curve.reset_index(drop=True, inplace=True)
-        self.start = self.curve[self.datetime_field].iloc[0]
-        self.end = self.curve[self.datetime_field].iloc[-1]
+        self.start = self.curve[self.datetime_field].min()
+        self.end = self.curve[self.datetime_field].max()
 
     def apply_chauvenet(self, magn='ai'):
         new_pp = self.copy()

--- a/powerprofile/powerprofile.py
+++ b/powerprofile/powerprofile.py
@@ -710,7 +710,7 @@ class PowerProfile():
         if default_data is None:
             default_data = {'ai': 0.0, 'ae': 0.0, 'r1': 0.0, 'r2': 0.0, 'r3': 0.0, 'r4': 0.0, 'valid': True, 'cch_fact': False}
 
-        if self.has_duplicates():
+        if self.has_duplicates()[0]:
             self.curve.drop_duplicates(subset=self.datetime_field)
 
         # creem un nou dataFrame amb una corba segons valors 'default_data'
@@ -731,6 +731,8 @@ class PowerProfile():
                 self.curve.loc[mask, column] = self.curve.loc[mask, self.datetime_field].dt.tz_convert(tz_info).values
 
         self.curve.reset_index(drop=True, inplace=True)
+        self.start = self.curve[self.datetime_field].iloc[0]
+        self.end = self.curve[self.datetime_field].iloc[-1]
 
     def apply_chauvenet(self, magn='ai'):
         new_pp = self.copy()

--- a/powerprofile/powerprofile.py
+++ b/powerprofile/powerprofile.py
@@ -727,8 +727,7 @@ class PowerProfile():
         # Check that relevant date columns will be filled with their respective timezone
         if ensure_filled is not None:
             for column, tz_info in ensure_filled:
-                mask = self.curve[column].isna()
-                self.curve.loc[mask, column] = self.curve.loc[mask, self.datetime_field].dt.tz_convert(tz_info).values
+                self.curve[column] = self.curve[self.datetime_field].dt.tz_convert(tz_info)
 
         self.curve.reset_index(drop=True, inplace=True)
         self.start = self.curve[self.datetime_field].iloc[0]


### PR DESCRIPTION
## Objetivos

- Arreglar la función fill gaps para que llene correctamente los agujeros
- `fill_gaps` solo llena el campo `datetime_field` dejando otros campos de fecha vacíos (`local_datetime`, `utc_datetime`, `timestamp`, etc.) haciendo imposible de serializar en XML-RPC. Se añade soporte para llenar campos adicionales.

## Comportamiento antiguo

- La función `fill_gaps` no llenaba correctamente los agujeros utilizando un índice incorrecto con `combine_first`

## Comportamiento nuevo

- Antes de utilizar el `combine_first` se reindexa con el campo fecha `datetime_field` para corregir el error.
- Se añade un parámetro opcional `ensure_filled` para rellenar campos de fecha adicionales.
- Cuando se añaden horas a la curva mediante `fill_gaps` se actualiza el valor de `start` y `end` acorde a la nueva curva.
- **USAGE**
```
extra_fields = [('local_datetime', 'Europe/Madrid')]
pp.fill_gaps(date_start, date_end, ensure_filled=extra_fields)
```
## Checklist

- [ ] Test code
