### PR TITLE
Afegim interpolació QH seguin el PO 10.5 Annex 11

### DIFF
--- a/powerprofile/utils.py
+++ b/powerprofile/utils.py
@@ -18,3 +18,97 @@ class Dragger(Counter):
         aprox = int(round(number))
         self[key] = number - aprox
         return aprox
+
+
+def interpolate_quarter_curve(values):
+    """
+    Interpola valors horaris en valors quarthoraris seguint el procediment
+    escrit a l'Annex 11 del BOE.
+
+    Parameters:
+    values : list of int or float
+        Llista ordenada de valors horaris on:
+        - values[1] fins a values[-2] representen els valors d'energia horària (E_h)
+        - values[0] és el valor inicial auxiliar (E_{h-1}) per la primera hora
+        - values[-1] és el valor final auxiliar (E_{h+1}) per l’última hora
+
+    Returns:
+    Generator
+        Una llista amb un diccionari per cada quart d’hora interpolat amb informació detallada.
+    """
+
+    def get_eh_idx(hour, quarter):
+        """
+        Determina quins valors horaris s’utilitzen per interpolar segons si el quart és el 1r/2n o 3r/4t.
+        """
+        return (hour, hour - 1) if quarter in (1, 2) else (hour + 1, hour)
+
+    def get_xqh(hour, quarter):
+        """
+        Calcula la posició temporal (abscissa) del quart d’hora dins del bloc horari.
+        """
+        return (hour - 1) + 0.125 + 0.25 * (quarter - 1)
+
+    def get_xhd(hour, quarter):
+        """
+        Retorna les posicions abscisses x_{h+1} i x_{h-1} segons la posició del quart.
+        """
+        hour -= 1
+        if quarter in (1, 2):
+            return (hour + 0.5, hour - 0.5)
+        else:
+            return (hour + 1.5, hour + 0.5)
+
+    # Si els extrems no estan inicialitzats, se substitueixen pel veí immediat
+    if values[0] is None:
+        values[0] = values[1]
+    if values[-1] is None:
+        values[-1] = values[-2]
+
+    result = []
+    qt = 1  # Índex global de quart-hora
+
+    # Iterem per cada hora central (les reals a interpolar)
+    for h in range(1, len(values) - 1):
+        sum_ehd = 0.0
+        qh_data = {}
+
+        # Interpolació lineal segons fórmula oficial: E'_{qhd}
+        for q in range(1, 5):
+            hi, hm = get_eh_idx(h, q)
+            xqh = get_xqh(h, q)
+            xhd, xhd_1 = get_xhd(h, q)
+
+            ehd = values[hm] + ((values[hi] - values[hm]) / (xhd - xhd_1)) * (xqh - xhd_1)
+            eqhd = ehd / 4.0
+
+            qh_data[q] = {
+                'hour': h,
+                'quarter': q,
+                'qt_index': qt,
+                'xqh': xqh,
+                'ehd': ehd,
+                'eqhd': eqhd,
+            }
+
+            sum_ehd += eqhd
+            qt += 1
+
+        # Ajust per assegurar que la suma de quarts sigui exactament igual a E_h
+        diff = values[h] - sum_ehd
+        rounded_sum = 0
+
+        for q in range(1, 5):
+            norm_qh = qh_data[q]['eqhd'] + ((diff * qh_data[q]['eqhd']) / sum_ehd)
+            if q < 4:
+                round_qh = int(round(norm_qh))
+                rounded_sum += round_qh
+            else:
+                round_qh = int(values[h] - rounded_sum)  # Últim quart compensa l’ajust
+
+            qh_data[q].update({
+                'diff': diff,
+                'norm_qh': norm_qh,
+                'round_qh': round_qh,
+            })
+            yield qh_data[q]

--- a/spec/interpolate_spec.py
+++ b/spec/interpolate_spec.py
@@ -1,0 +1,34 @@
+# coding: utf-8
+from mamba import *
+from expects import *
+from powerprofile.utils import interpolate_quarter_curve
+
+
+with description('interpolate_quarter_curve'):
+    with context('REE simulator validation'):
+        with it('generates exact quarter-hour results from REE simulator'):
+
+            values = [
+                1105, 1279, 1354, 1338, 1327, 1386, 1471, 1590, 1639, 1791, 1788, 1820,
+                1776, 1742, 1795, 1653, 1511, 1441, 1596, 1604, 1508, 1429, 1477, 1390,
+                1326, 1258,
+            ]
+
+            # Valors de referència extrets del simulador (ajust final)
+            expected_round_qh = [
+                306, 317, 325, 331, 334, 339, 341, 340, 336, 335, 334, 333, 331,
+                330, 331, 335, 340, 344, 348, 354, 359, 364, 370, 378, 388, 396,
+                401, 405, 402, 405, 411, 421,438, 448, 453, 452, 446, 446, 447,
+                449, 454, 456, 456, 454, 448, 445, 443, 440, 436, 434, 434, 438,
+                450, 453, 450, 442, 427, 418, 409, 399, 389, 380, 373, 369, 360,
+                355, 358, 368, 389, 399, 404, 404, 404, 404, 401, 395, 385, 379,
+                374, 370, 361, 356, 355, 357, 369, 372, 371, 365, 355, 349, 345,
+                341, 338, 334, 329, 325,
+            ]
+
+            # També podries incloure els valors "norm_qh" si vols validar precisió
+
+            result = list(interpolate_quarter_curve(values))
+            actual_round_qh = [item['round_qh'] for item in result]
+
+            expect(actual_round_qh).to(equal(expected_round_qh))


### PR DESCRIPTION
## Objetivos

- Afegim la funció `to_qh` al mòdul `powerprofile` per convertir una corba horària en una corba de quart d’hora utilitzant interpolació.
- Introduïm la funció `interpolate_quarter_curve` com a utilitat per interpolar valors horaris en valors de quart d’hora.
- Afegim proves unitàries per validar la funcionalitat d’aquestes noves eines.

## Comportamiento antiguo

- No existia cap funció per convertir corbes horàries en corbes de quart d’hora.
- No hi havia cap utilitat d’interpolació per gestionar aquests casos ni proves unitàries associades.

## Comportamiento nuevo

- Es pot utilitzar el mètode `to_qh` per convertir corbes horàries en corbes de quart d’hora, assegurant que els valors interpolats siguin consistents i compleixin amb la suma horària.
- La funció `interpolate_quarter_curve` permet interpolar valors horaris a quart d’hora amb gestió d’inicialització i tancament dels valors extrems.
- Es valida la funcionalitat amb proves unitàries al fitxer `interpolate_spec.py` i al fitxer `powerprofileqh_spec.py`.

## Relacionado

- TASK-72506

## Checklist

- [ ] Test code