### PR TITLE
Adaptar función de interpolado de horario a cuartohorario para que no de error en caso de que la curva tenga valores con 0

### DIFF
--- a/powerprofile/utils.py
+++ b/powerprofile/utils.py
@@ -99,7 +99,11 @@ def interpolate_quarter_curve(values):
         rounded_sum = 0
 
         for q in range(1, 5):
-            norm_qh = qh_data[q]['eqhd'] + ((diff * qh_data[q]['eqhd']) / sum_ehd)
+            # norm_qh = qh_data[q]['eqhd'] + ((diff * qh_data[q]['eqhd']) / sum_ehd)
+            if sum_ehd:
+                norm_qh = qh_data[q]['eqhd'] + ((diff * qh_data[q]['eqhd']) / sum_ehd)
+            else:
+                norm_qh = 0
             if q < 4:
                 round_qh = int(round(norm_qh))
                 rounded_sum += round_qh

--- a/spec/interpolate_spec.py
+++ b/spec/interpolate_spec.py
@@ -32,3 +32,27 @@ with description('interpolate_quarter_curve'):
             actual_round_qh = [item['round_qh'] for item in result]
 
             expect(actual_round_qh).to(equal(expected_round_qh))
+        with it('generates exact quarter-hour results from REE simulator with 3 hours in a row to 0'):
+
+            values = [
+                1105, 0, 0, 0, 1327, 1386, 1471, 1590, 1639, 1791, 1788, 1820,
+                1776, 1742, 1795, 1653, 1511, 1441, 1596, 1604, 1508, 1429, 1477, 1390,
+                1326, 1258,
+            ]
+            # Valors de referència extrets del simulador (ajust final)
+            expected_round_qh = [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 235,
+                330, 379, 383, 340, 344, 348, 354, 359, 364, 370, 378, 388, 396,
+                401, 405, 402, 405, 411, 421, 438, 448, 453, 452, 446, 446, 447,
+                449, 454, 456, 456, 454, 448, 445, 443, 440, 436, 434, 434, 438,
+                450, 453, 450, 442, 427, 418, 409, 399, 389, 380, 373, 369, 360,
+                355, 358, 368, 389, 399, 404, 404, 404, 404, 401, 395, 385, 379,
+                374, 370, 361, 356, 355, 357, 369, 372, 371, 365, 355, 349, 345,
+                341, 338, 334, 329, 325,
+            ]
+
+            # També podries incloure els valors "norm_qh" si vols validar precisió
+            result = list(interpolate_quarter_curve(values))
+            actual_round_qh = [item['round_qh'] for item in result]
+
+            expect(actual_round_qh).to(equal(expected_round_qh))


### PR DESCRIPTION
## Comportamiento antiguo

- Al llamar la función `interpolate_quarter_curve` para interpolar una curva horaria a quartoraria si 3 horas seguidas tenian valor 0 saltaba un error de division por 0
## Comportamiento nuevo

- Se ha corregido la función para que no salte el error de division por 0

## Relacionado

https://github.com/gisce/powerprofile/pull/48

## Checklist

- [x] Test code
