### PR TITLE
Remove old setup and use pyproject.toml and tox instead

### DIFF
--- a/.github/workflows/python2.7-app.yml
+++ b/.github/workflows/python2.7-app.yml
@@ -29,10 +29,14 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools
+        pip install virtualenv
+        virtualenv venv
+        . venv/bin/activate
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
         pip install coveralls
         pip install -e .
     - name: Test with mamba
       run: |
+        . venv/bin/activate
         mamba --enable-coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,24 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build package
+        run: python -m build
+
+      - name: Check distribution metadata
+        run: twine check dist/*
+
       - name: Get tag
         id: tag
         uses: dawidd6/action-get-tag@v1
         with:
           strip_v: false
 
-      - name: Creating a realease/pre-release
+      - name: Creating a release/pre-release
         id: create_release
         uses: softprops/action-gh-release@v1
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=77", "wheel"]
+requires = ["setuptools>=44", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=77", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "powerprofile"
+version = "0.23.4"
+description = "Library to manage power profiles"
+readme = "README.md"
+requires-python = ">=2.7"
+license = "AGPL-3.0-only"
+authors = [
+  {name = "GISCE-TI, S.L.", email = "devel@gisce.net"},
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python :: 2.7",
+  "Programming Language :: Python :: 3.11",
+  "Topic :: Utilities"
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/gisce/powerprofile"
+
+[tool.setuptools]
+package-dir = {"" = "."}
+
+[tool.setuptools.packages.find]
+exclude = ["tests", "docs", "examples"]
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
+
+[tool.setuptools.dynamic.optional-dependencies]
+test = {file = ["requirements-dev.txt"]}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
-mamba<0.11.0
+mamba<0.11.0;python_version<="2.7.18"
+mamba;python_version>"2.7.18"
 expects

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py27, py311
+requires = setuptools>=77.0.0, tox>=4.0
+
+[testenv]
+deps =
+    -rrequirements.txt
+    -rrequirements-dev.txt
+commands = mamba spec/


### PR DESCRIPTION
## Objetivos

- Actualizar libreria para usar pyproject.toml en vez de setup.py para buildear
- Añadir tox.ini para tests

## Comportamiento antiguo

-

## Comportamiento nuevo

- 

## Relacionado

*Puedes ver todas las [posibles palabras para accionesa automáticas con el mensaje](https://help.github.com/articles/closing-issues-using-keywords/)*

## Checklist

- [ ] Test code
